### PR TITLE
Add visual transcription of notes on a music sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Music App
 
-This is a web application that allows playing sounds by pressing keyboard keys and dynamically displays the played notes on a music sheet.
+This is a web application that allows playing sounds by pressing keyboard keys and dynamically displays the played notes on a music sheet according to the treble clef with C at the bottom.
 
 ## Project Structure
 
@@ -29,7 +29,7 @@ music-app/
 
 ## Frontend
 
-The frontend is built using React, Tone.js, and VexFlow. It handles the user interface, keyboard input, sound generation, and dynamic music sheet display.
+The frontend is built using React, Tone.js, and VexFlow. It handles the user interface, keyboard input, sound generation, and dynamic music sheet display using VexFlow.
 
 ## Backend
 

--- a/music-app/frontend/src/App.jsx
+++ b/music-app/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import * as Tone from 'tone';
+import Vex from 'vexflow';
 
 function App() {
   const [synth, setSynth] = useState(null);
@@ -42,6 +43,16 @@ function App() {
     };
   }, [instrument]); // Recréer le synthétiseur quand l'instrument change
 
+  useEffect(() => {
+    const VF = Vex.Flow;
+    const div = document.getElementById("music-sheet");
+    const renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);
+    renderer.resize(500, 200);
+    const context = renderer.getContext();
+    const stave = new VF.Stave(10, 40, 400);
+    stave.addClef("treble").setContext(context).draw();
+  }, []);
+
   // Mapping des touches du clavier aux notes
   const keyMap = {
     'q': 'C4',
@@ -54,12 +65,37 @@ function App() {
     'k': 'C5'
   };
 
+  const drawNotes = (note) => {
+    const VF = Vex.Flow;
+    const div = document.getElementById("music-sheet");
+    const renderer = new VF.Renderer(div, VF.Renderer.Backends.SVG);
+    renderer.resize(500, 200);
+    const context = renderer.getContext();
+    const stave = new VF.Stave(10, 40, 400);
+    stave.addClef("treble").setContext(context).draw();
+
+    const notes = [
+      new VF.StaveNote({
+        clef: "treble",
+        keys: [note],
+        duration: "q"
+      })
+    ];
+
+    const voice = new VF.Voice({ num_beats: 1, beat_value: 4 });
+    voice.addTickables(notes);
+
+    const formatter = new VF.Formatter().joinVoices([voice]).format([voice], 400);
+    voice.draw(context, stave);
+  };
+
   // Gérer l'appui sur une touche
   const handleKeyDown = (event) => {
     const note = keyMap[event.key.toLowerCase()];
     if (note && synth) {
       synth.triggerAttackRelease(note, '8n');
       setNotes(prev => [...prev, `${instrumentNames[instrument]}: ${note}`]);
+      drawNotes(note);
     }
   };
 
@@ -129,6 +165,7 @@ function App() {
               if (synth) {
                 synth.triggerAttackRelease(note, '8n');
                 setNotes(prev => [...prev, `${instrumentNames[instrument]}: ${note}`]);
+                drawNotes(note);
               }
             }}
           >
@@ -171,8 +208,11 @@ function App() {
           ))}
         </div>
       </div>
+
+      {/* Partition de musique */}
+      <div id="music-sheet" style={{ marginTop: '20px' }}></div>
     </div>
   );
 }
 
-export default App; 
+export default App;


### PR DESCRIPTION
Add functionality to visually transcribe notes on a music sheet according to the treble clef with C at the bottom.

* **App.jsx**
  - Import `Vex` from `vexflow`.
  - Add a `useEffect` hook to initialize the VexFlow renderer and stave.
  - Add a function to draw notes on the stave using VexFlow.
  - Update the `handleKeyDown` function to call the draw notes function.
  - Add a `div` element with an id of `music-sheet` to the JSX return.

* **README.md**
  - Update the description to mention the visual transcription of notes on a music sheet.
  - Update the frontend section to include VexFlow usage for music sheet display.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Jibert107/SyntPaper/pull/4?shareId=de5bb790-d826-464b-aec8-fae41bd48058).